### PR TITLE
Footer Set in mobile Desktop mode

### DIFF
--- a/css/footer.css
+++ b/css/footer.css
@@ -1,14 +1,23 @@
 /* ********************************* Footer Section ********************************* */
 
+body{
+  min-height: 100vh ;
+}
+
 footer {
   margin: 6rem 0 0;
   padding: 4rem 4rem 2rem;
-  position: relative;
+  margin-bottom: 0px;
+  /* position: relative; */
+  position: sticky;
+  top: 100%;
   background: var(--darkblack);
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   flex-wrap: wrap;
+  height: 100%;
+  width: 100%;
 }
 
 /* ********************************* Footer Desc ********************************* */

--- a/css/home.css
+++ b/css/home.css
@@ -1,5 +1,7 @@
 /* ********************************* Home Page Styles ********************************* */
-
+body{
+  min-height: 100vh ;
+}
 .landing-wrapper {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What changes have you made?

When i open GDSC Official website in mobile desktop mode then due to lack of content in some pages like : Home page, About page and Doubts page **Footer comes up little bit from bottom** . This **issue** has been solved by me and now website footer will remains always sticky at bottom even in the mobile  Desktop mode .



## Checklist
Before you create this PR, confirm all the requirements listed below by checking the checkboxes [x]:

- [x] I am making a proper pull request, not spam.
- [x] I've checked the issue list before deciding what to submit.
- [x] I have checked there aren't other open Pull Requests for the same update/change
- [x] I have tested the code before submission
- [ ] I am a member of GDSC JGEC
- [ ] I'm Hacktoberfest'21 contributor.

## Related Issues or Pull Requests

(Write your answer here.)

## Add relevant screenshot or video (if any)

https://rko0211.github.io/gdscjgec.github.io/

Before :-1: 

![WhatsApp Image 2023-08-27 at 8 34 43 PM](https://github.com/gdscjgec/gdscjgec.github.io/assets/97402824/1e7f4798-a8aa-42de-8180-7a9c0aae2212)

Now :+1: 

![WhatsApp Image 2023-08-27 at 8 48 45 PM](https://github.com/gdscjgec/gdscjgec.github.io/assets/97402824/aba7ca70-f5d3-4202-b167-16ce103f845a)

